### PR TITLE
fix password string for connecting to the postgres db.

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -1,4 +1,3 @@
-// configs/config.yaml
 server:
   port: 8080
   read_timeout: 5s
@@ -9,14 +8,13 @@ database:
   host: localhost
   port: 5432
   user: prateekkumar
-  password: 
+  password: ""
   dbname: chat_app
   sslmode: disable
-
 jwt:
   secret_key: "super-secret-key-that-is-at-least-32-characters"
-  access_expiry: 15m   # 15 minutes
-  refresh_expiry: 24h  # 24 hours
+  access_expiry: 15m
+  refresh_expiry: 24h
 
 auth:
   password_min_length: 8


### PR DESCRIPTION
By default the Postgres.app doesn't set any password for any of the database created. However, we still need to mark it as an empty string. Making that change in this PR now. 