### PR TITLE
fix the module name of the application from chatpp to the correct one. 

### DIFF
--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"strings"
 
-	"chat-app/internal/models"
-	"chat-app/pkg/logger"
-	"chat-app/pkg/validator"
+	"github.com/codingminions/Whatsapp-Lite/internal/models"
+	"github.com/codingminions/Whatsapp-Lite/pkg/logger"
+	"github.com/codingminions/Whatsapp-Lite/pkg/validator"
 )
 
 // Handler handles auth-related HTTP requests
@@ -220,3 +220,4 @@ func (h *Handler) Logout(w http.ResponseWriter, r *http.Request) {
 
 	// Send response
 	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"strings"
 
-	"chat-app/internal/models"
-	"chat-app/pkg/logger"
-	"chat-app/pkg/token"
+	"github.com/codingminions/Whatsapp-Lite/internal/models"
+	"github.com/codingminions/Whatsapp-Lite/pkg/logger"
+	"github.com/codingminions/Whatsapp-Lite/pkg/token"
 )
 
 // contextKey is a custom type for context keys to avoid collisions

--- a/internal/auth/repository.go
+++ b/internal/auth/repository.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jmoiron/sqlx"
 
-	"chat-app/internal/models"
+	"github.com/codingminions/Whatsapp-Lite/internal/models"
 )
 
 // Repository errors
@@ -45,8 +45,8 @@ func (r *PostgresRepository) CreateUser(ctx context.Context, user *models.User) 
 	query := `
 		INSERT INTO users (username, email, password_hash, status, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6)
-		RETURNING id
-	`
+		RETURNING id 
+		`
 
 	err := r.db.QueryRowContext(
 		ctx,

--- a/internal/auth/service.go
+++ b/internal/auth/service.go
@@ -8,9 +8,9 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/crypto/bcrypt"
 
-	"chat-app/internal/models"
-	"chat-app/pkg/logger"
-	"chat-app/pkg/token"
+	"github.com/codingminions/Whatsapp-Lite/internal/models"
+	"github.com/codingminions/Whatsapp-Lite/pkg/logger"
+	"github.com/codingminions/Whatsapp-Lite/pkg/token"
 )
 
 // Service errors


### PR DESCRIPTION
This pull request updates import statements across multiple files, changing them from the relative path "chat-app/internal/models" to the absolute path "github.com/codingminions/Whatsapp-Lite/internal/models". This modification aligns with Go's module system, which requires absolute import paths to ensure clarity and consistency, especially when managing dependencies and facilitating collaboration. By specifying the full module path, the codebase becomes more maintainable and compatible with Go's tooling and package resolution mechanisms. 