### PR TITLE
Updated the router configuration to include explicit HTTP method checks

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,12 +10,12 @@ import (
 	"syscall"
 	"time"
 
-	"chat-app/configs"
-	"chat-app/internal/auth"
-	"chat-app/pkg/database"
-	"chat-app/pkg/logger"
-	"chat-app/pkg/token"
-	"chat-app/pkg/validator"
+	"github.com/codingminions/Whatsapp-Lite/configs"
+	"github.com/codingminions/Whatsapp-Lite/internal/auth"
+	"github.com/codingminions/Whatsapp-Lite/pkg/database"
+	"github.com/codingminions/Whatsapp-Lite/pkg/logger"
+	"github.com/codingminions/Whatsapp-Lite/pkg/token"
+	"github.com/codingminions/Whatsapp-Lite/pkg/validator"
 )
 
 func main() {
@@ -92,11 +92,36 @@ func main() {
 		serveTemplate("./web/templates/chat.html")(w, r)
 	})
 
-	// Auth API routes
-	router.HandleFunc("POST /auth/register", authHandler.Register)
-	router.HandleFunc("POST /auth/login", authHandler.Login)
-	router.HandleFunc("POST /auth/refresh", authHandler.Refresh)
-	router.HandleFunc("POST /auth/logout", func(w http.ResponseWriter, r *http.Request) {
+	// Auth API routes - Using method check for Go 1.21 compatibility
+	router.HandleFunc("/auth/register", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		authHandler.Register(w, r)
+	})
+
+	router.HandleFunc("/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		authHandler.Login(w, r)
+	})
+
+	router.HandleFunc("/auth/refresh", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		authHandler.Refresh(w, r)
+	})
+
+	router.HandleFunc("/auth/logout", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
 		authMiddleware.Authenticate(http.HandlerFunc(authHandler.Logout)).ServeHTTP(w, r)
 	})
 


### PR DESCRIPTION
In Go 1.21, the `http.ServeMux` does not support method-specific patterns directly in the HandleFunc method. As noted in the [Go 1.22 Routing Enhancements](https://go.dev/blog/routing-enhancements), method matching and wildcards were introduced in Go 1.22 to allow more expressive routing patterns. 

Previously, the router was configured using patterns like router.HandleFunc("POST /auth/register", authHandler.Register), which directly associated HTTP methods with specific routes.. However, since our project is currently using Go 1.21, we needed to implement method checks manually within our handlers to ensure that only requests with the correct HTTP method are processed.​